### PR TITLE
merge: improve console output for optional fields

### DIFF
--- a/formatters/console_weather_formatter.py
+++ b/formatters/console_weather_formatter.py
@@ -34,6 +34,11 @@ class ConsoleFormatter:
         welcome_text = Text("Welcome! 😊", justify="center")
         self.console.print(Panel(welcome_text, expand=True, padding=(1, 2)))
 
+    def _format_optional_fields(self, value, metric: str="", placeholder="N/A"):
+        if value is None:
+            return placeholder
+        return f"{value}{metric}"
+
     def print_weather_info(self, weather_data: WeatherDTO):
         self.clear_console()
         self.print_header()
@@ -44,13 +49,13 @@ class ConsoleFormatter:
         temp_min = weather_data.temp_min
         temp_max = weather_data.temp_max
         pressure = weather_data.pressure
-        wind_speed = weather_data.wind_speed
-        wind_dir = weather_data.wind_dir
-        visibility = weather_data.visibility_km
-        clouds = weather_data.clouds
+        wind_speed = self._format_optional_fields(weather_data.wind_speed, " м/с")
+        wind_dir = self._format_optional_fields(weather_data.wind_dir)
+        visibility = self._format_optional_fields(weather_data.visibility_km, " км")
+        clouds = self._format_optional_fields(weather_data.clouds, "%")
         humidity = weather_data.humidity
-        sunrise = weather_data.sunrise
-        sunset = weather_data.sunset
+        sunrise = self._format_optional_fields(weather_data.sunrise)
+        sunset = self._format_optional_fields(weather_data.sunset)
         description = weather_data.description
 
         # Панель для температуры
@@ -63,9 +68,9 @@ class ConsoleFormatter:
 
         # Панель для ветра
         wind_panel = (
-            f"💨  Ветер:            {wind_speed} м/с, {wind_dir}\n"
-            f"🌫️  Видимость:        {visibility} км\n"
-            f"☁️  Облачность:       {clouds}%"
+            f"💨  Ветер:            {wind_speed}, {wind_dir}\n"
+            f"🌫️  Видимость:        {visibility}\n"
+            f"☁️  Облачность:       {clouds}"
         )
 
         # Панель для влажности и давления


### PR DESCRIPTION
## Description

This pull request improves the console output for optional weather fields in `ConsoleFormatter`. Previously, fields such as wind speed, visibility, clouds, sunrise, and sunset could appear as `None`, which was not user-friendly.

Now, missing values are displayed with a placeholder (`"N/A"` by default). This makes the console output clearer and easier to read.

## Changes

### ConsoleFormatter
- Added `_format_optional_fields()` helper method to handle `None` values and append optional metric suffixes.
- Updated `print_weather_info()` to use `_format_optional_fields()` for wind, visibility, clouds, sunrise, and sunset.
- Ensures consistent, readable output even when the service returns incomplete data.
- Future improvement: the formatter may be refactored for localization and more flexible display.

## Reason for Changes
- **User experience:** prevents raw `None` values from being printed in the console.
- **Consistency:** ensures all optional fields have a clear, readable output.
- **Maintainability:** centralizes `None` handling in a single helper method.

## Notes
- This is a temporary improvement; the console formatter will be refactored in the future to support better formatting, localization, and flexible display.

## References
- Fixes #9
- OpenWeather API documentation regarding optional fields
